### PR TITLE
Networktables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frcrs"
-version = "0.1.3"
+version = "0.1.5"
 edition = "2021"
 license = "MIT"
 description = "A robotics control framework designed to streamline the development of control systems for FRC robots"

--- a/src/drive/swerve.rs
+++ b/src/drive/swerve.rs
@@ -103,7 +103,7 @@ impl Swerve {
         while _new_angle < lower_bound {
             _new_angle += 360.;
         }
-        while new_angle > upper_bound {
+        while _new_angle > upper_bound {
             _new_angle -= 360.;
         }
         if _new_angle - scope_ref > 180. {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,8 @@ pub mod limelight;
 pub mod redux;
 pub mod solenoid;
 pub mod telemetry;
-pub mod trapezoidal;
 pub mod trajectory;
+pub mod trapezoidal;
 
 use crate::input::{RobotMode, RobotState};
 use jni::objects::{JObject, JValue};

--- a/src/networktables/networktable.rs
+++ b/src/networktables/networktable.rs
@@ -74,6 +74,36 @@ pub struct NetworkTableEntry {
 }
 
 impl NetworkTableEntry {
+    pub fn set_float(&self, value: f64) {
+        call!(
+            &self.instance,
+            "edu/wpi/first/networktables/NetworkTableEntry",
+            "setDouble",
+            "(D)V",
+            &[JValue::Double(value).as_jni()],
+            ReturnType::Primitive(Primitive::Void)
+        )
+        .v()
+        .unwrap()
+    }
+
+    pub fn set_string(&self, value: &str) {
+        let java_str = java().new_string(value).unwrap();
+        let java_obj: JObject = java_str.into();
+
+        // Borrow JObject as reference for JValue::Object
+        call!(
+            &self.instance,
+            "edu/wpi/first/networktables/NetworkTableEntry",
+            "setString",
+            "(Ljava/lang/String;)V",
+            &[JValue::Object(&java_obj).as_jni()],
+            ReturnType::Primitive(Primitive::Void)
+        )
+        .v()
+        .unwrap()
+    }
+
     pub fn get_float(&self) -> f64 {
         call!(
             &self.instance,
@@ -85,5 +115,24 @@ impl NetworkTableEntry {
         )
         .d()
         .unwrap()
+    }
+
+    pub fn get_string(&self) -> String {
+        let default_str = java().new_string("").unwrap();
+        let default_obj: JObject = default_str.into();
+
+        let result = call!(
+            &self.instance,
+            "edu/wpi/first/networktables/NetworkTableEntry",
+            "getString",
+            "(Ljava/lang/String;)Ljava/lang/String;",
+            &[JValue::Object(&default_obj).as_jni()],
+            ReturnType::Object
+        )
+        .l()
+        .unwrap();
+
+        // Borrow result for get_string call
+        java().get_string((&result).into()).unwrap().into()
     }
 }


### PR DESCRIPTION
added a few more nt methods such as set/get string and set/get float and fixed that one random line in swerve that kept failing clippy tested on robotcode everything worked fine will push to crates after pulled to master.