### PR TITLE
bump actions/checkout to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     name: Formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Read rust-toolchain.toml
         id: toolchain
@@ -31,7 +31,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Read rust-toolchain.toml
         id: toolchain


### PR DESCRIPTION
github will be deprecating node 20 in github actions

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

This looks like a really cool project, and thank you for still maintaining it!